### PR TITLE
代码生成器示例中方法被3.4.0删除，需更换

### DIFF
--- a/guide/generator.md
+++ b/guide/generator.md
@@ -30,7 +30,7 @@ public class CodeGenerator {
         System.out.println(help.toString());
         if (scanner.hasNext()) {
             String ipt = scanner.next();
-            if (StringUtils.isNotEmpty(ipt)) {
+            if (StringUtils.isNotBlank(ipt)) {
                 return ipt;
             }
         }


### PR DESCRIPTION
演示例子中，scanner方法引用的工具类StringUtils的isNotEmpty方法在3.4.0中已删除，需替换成isNotBlank方法