### PR TITLE
Update quick-start.md

### DIFF
--- a/guide/quick-start.md
+++ b/guide/quick-start.md
@@ -153,7 +153,6 @@ public interface UserMapper extends BaseMapper<User> {
 添加测试类，进行功能测试：
 
 ```java
-@RunWith(SpringRunner.class)
 @SpringBootTest
 public class SampleTest {
 


### PR DESCRIPTION
在spring-boot-starter-parent的版本为2.4.5中，spring-boot-start-test 依赖的junit-jupiter， 不在需要使用junit中的@RunWith注解。