### PR TITLE
在3.4.1 版本中 @TableId注解的属性 type的默认值 似乎不是NONE 而是ASSIGN_ID

### DIFF
--- a/guide/annotation.md
+++ b/guide/annotation.md
@@ -35,7 +35,7 @@ mp会自动构建一个`ResultMap`并注入到mybatis里(一般用不上).下面
 | 属性 | 类型 | 必须指定 | 默认值 | 描述 |
 | :-: | :-: | :-: | :-: | :-: |
 | value | String | 否 | "" | 主键字段名 |
-| type | Enum | 否 | IdType.NONE | 主键类型 |
+| type | Enum | 否 | IdType.ASSIGN_ID | 主键类型 |
 
 #### [IdType](https://github.com/baomidou/mybatis-plus/blob/3.0/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/IdType.java)
 
@@ -44,7 +44,7 @@ mp会自动构建一个`ResultMap`并注入到mybatis里(一般用不上).下面
 | AUTO | 数据库ID自增 |
 | NONE | 无状态,该类型为未设置主键类型(注解里等于跟随全局,全局里约等于 INPUT) |
 | INPUT | insert前自行set主键值 |
-| ASSIGN_ID | 分配ID(主键类型为Number(Long和Integer)或String)(since 3.3.0),使用接口`IdentifierGenerator`的方法`nextId`(默认实现类为`DefaultIdentifierGenerator`雪花算法) |
+| ASSIGN_ID | 分配ID(主键类型为Long或String)(since 3.3.0),使用接口`IdentifierGenerator`的方法`nextId`(默认实现类为`DefaultIdentifierGenerator`雪花算法) |
 | ASSIGN_UUID | 分配UUID,主键类型为String(since 3.3.0),使用接口`IdentifierGenerator`的方法`nextUUID`(默认default方法)
 | ~~ID_WORKER~~ | 分布式全局唯一ID 长整型类型(please use `ASSIGN_ID`) |
 | ~~UUID~~ | 32位UUID字符串(please use `ASSIGN_UUID`) |


### PR DESCRIPTION
在3.4.1 版本中 @TableId注解的属性 type的默认值 似乎不是NONE 而是ASSIGN_ID  并且Integer范围太小 无法承载雪花算法的值