### PR TITLE
Update 01.代码生成器配置新.md

### DIFF
--- a/docs/02.配置/02.代码生成器配置/01.代码生成器配置新.md
+++ b/docs/02.配置/02.代码生成器配置/01.代码生成器配置新.md
@@ -73,7 +73,7 @@ new GlobalConfig.Builder()
 | service(String)                   | Service 包名      | 默认值:service                                         |
 | serviceImpl(String)               | Service Impl 包名 | 默认值:service.impl                                    |
 | mapper(String)                    | Mapper 包名       | 默认值:mapper                                          |
-| mapperXml(String)                 | Mapper XML 包名   | 默认值:mapper.xml                                      |
+| xml(String)                 | Mapper XML 包名   | 默认值:mapper.xml                                      |
 | controller(String)                | Controller 包名   | 默认值:controller                                      |
 | other(String)                     | 自定义文件包名    | 输出自定义文件时所用到的包名                           |
 | pathInfo(Map<OutputFile, String>) | 路径配置信息      | Collections.singletonMap(OutputFile.mapperXml, "D://") |
@@ -86,7 +86,7 @@ new PackageConfig.Builder()
     .service("service")
     .serviceImpl("service.impl")
     .mapper("mapper")
-    .mapperXml("mapper.xml")
+    .xml("mapper.xml")
     .controller("controller")
     .other("other")
     .pathInfo(Collections.singletonMap(OutputFile.mapperXml, "D://"))


### PR DESCRIPTION
包配置(PackageConfig)中的mapperXml(String)应为xml(String)