### PR TITLE
docs: 添加SpringBoot 3.0版本在使用当前 MP 版本无法自动注册 Mapper 问题的临时解决方案

### DIFF
--- a/docs/01.指南/01.快速入门/03.安装.md
+++ b/docs/01.指南/01.快速入门/03.安装.md
@@ -34,6 +34,18 @@ Gradle：
 compile group: 'com.baomidou', name: 'mybatis-plus-boot-starter', version: '最新版本'
 ```
 
+#### 针对当前版本在 Spring Boot 3 版本中使用的特别说明
+
+如果您使用了 Spring Boot 3.x 版本，在当前版本下需要在 `resources` 文件夹下创建文件 `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`，并添加如下代码：
+```plain
+com.baomidou.mybatisplus.autoconfigure.IdentifierGeneratorAutoConfiguration
+com.baomidou.mybatisplus.autoconfigure.MybatisPlusLanguageDriverAutoConfiguration
+com.baomidou.mybatisplus.autoconfigure.MybatisPlusAutoConfiguration
+```
+
+> Spring 团队在 Spring Boot 2.7 版本开始引入通过 `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` 注册自动配置，并在 3.0 版本**完全**移除了通过 `META-INF/spring.factories` 文件注册自动配置类的方式。
+> 可参考 [Spring Boot 3.0 Migration Guide#Auto Configuration Files](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files)。
+
 ### Spring
 
 Maven:


### PR DESCRIPTION
这是 [Issue #5032](https://github.com/baomidou/mybatis-plus/issues/5032) 的临时解决方案