### PR TITLE
文档 “防全表更新与删除插件” 头部出现无意义信息

### DIFF
--- a/docs/01.指南/01.快速入门/02.快速开始.md
+++ b/docs/01.指南/01.快速入门/02.快速开始.md
@@ -113,7 +113,6 @@ INSERT INTO user (id, name, age, email) VALUES
 spring:
   datasource:
     driver-class-name: org.h2.Driver
-    schema: classpath:db/schema-h2.sql
     username: root
     password: test
   sql:

--- a/docs/01.指南/04.插件/05.防全表更新与删除插件.md
+++ b/docs/01.指南/04.插件/05.防全表更新与删除插件.md
@@ -2,12 +2,7 @@
 title: 防全表更新与删除插件
 date: 2022-10-31 10:55:24
 permalink: /pages/c571bc/
----
-title: 防全表更新与删除插件
-date: 2021-12-14 19:13:02
-permalink: /pages/f9a237/
 article: false
-
 ---
 
 ## BlockAttackInnerInterceptor


### PR DESCRIPTION
文档 [防全表更新与删除插件](https://baomidou.com/pages/c571bc/) 出现如下图无意义信息（Front Matter）：
![useless](https://user-images.githubusercontent.com/22262771/229310759-6c199c81-fa6e-43d3-8207-978228e8c777.png)

其他：
- 文件 快速开始 的 schema 配置已 弃用，在 spring.sql,init 中配置（之前 PR spring-boot-starter-parent 版本问题时忘记提交）