### PR TITLE
Update 03.安装.md

### DIFF
--- a/docs/01.指南/01.快速入门/03.安装.md
+++ b/docs/01.指南/01.快速入门/03.安装.md
@@ -31,7 +31,10 @@ Maven：
 Gradle：
 
 ```groovy
+//Gradle Version:<4.1
 compile group: 'com.baomidou', name: 'mybatis-plus-boot-starter', version: '最新版本'
+//Gradle Version:>=4.1 (The function compile has been deprecated since Gradle 4.10, and removed since Gradle 7.0. Please use implementation instead.)
+implementation 'com.baomidou:mybatis-plus-boot-starter:最新版本'
 ```
 
 ### Spring
@@ -49,7 +52,11 @@ Maven:
 Gradle：
 
 ```groovy
+//Gradle Version:<4.1
 compile group: 'com.baomidou', name: 'mybatis-plus', version: '最新版本'
+//Gradle Version:>=4.1 (The function compile has been deprecated since Gradle 4.10, and removed since Gradle 7.0. Please use implementation instead.)
+implementation 'com.baomidou:mybatis-plus:最新版本'
+
 ```
 
 ---


### PR DESCRIPTION
gradle在版本4.1之后，compile方法被弃用，并在7.0版本删除。(compile, runtime, testCompile, testRuntime在版本4.1之后应替换为implementation, runtimeOnly, testImplementation, testRuntimeOnly)