### PR TITLE
更正注解配置 @TableField 中关于 updateStrategy 的示例描述

### DIFF
--- a/src/content/docs/reference/annotation.mdx
+++ b/src/content/docs/reference/annotation.mdx
@@ -416,7 +416,7 @@ public class User {
 }
 ```
 
-在这个例子中，`@TableField(updateStrategy = FieldStrategy.IGNORED)` 注解告诉 MyBatis-Plus，在更新用户信息时，总是将 nickname 字段包含在 UPDATE 语句的 SET 子句中，忽略其值的检查。
+在这个例子中，`@TableField(updateStrategy = FieldStrategy.ALWAYS)` 注解告诉 MyBatis-Plus，在更新用户信息时，总是将 nickname 字段包含在 UPDATE 语句的 SET 子句中，忽略其值的检查。
 
 如果我们执行以下更新操作：
 


### PR DESCRIPTION
### 文档中原文为：

**示例说明**

假设我们有一个实体类 User，其中包含一个 nickname 字段，我们希望在更新用户信息时，总是更新 nickname 字段，无论其值是否为空。我们可以使用 @TableField 注解的 updateStrategy 属性来实现这个功能：

```java
import com.baomidou.mybatisplus.annotation.TableField;
import com.baomidou.mybatisplus.annotation.FieldStrategy;

@TableName("sys_user")
public class User {
    @TableId
    private Long id;

    @TableField(updateStrategy = FieldStrategy.ALWAYS) // 总是更新 nickname，忽略值的检查
    private String nickname;

    private Integer age;

    private String email;
}
```

在这个例子中，`@TableField(updateStrategy = FieldStrategy.IGNORED)` 注解告诉 MyBatis-Plus，在更新用户信息时，总是将 nickname 字段包含在 UPDATE 语句的 SET 子句中，忽略其值的检查。

### 修改：
将描述`@TableField(updateStrategy = FieldStrategy.IGNORED)`更正为`@TableField(updateStrategy = FieldStrategy.ALWAYS)`。