### PR TITLE
fix: pageMaps example typo

### DIFF
--- a/src/content/docs/guides/data-interface.mdx
+++ b/src/content/docs/guides/data-interface.mdx
@@ -856,7 +856,7 @@ SELECT * FROM user WHERE age > 25 LIMIT 10 OFFSET 0
 
 ```java
 // 假设要进行无条件的分页查询，并将结果映射为 Map，每页显示10条记录，查询第1页
-IPage<User> page = new Page<>(1, 10);
+IPage<Map<String, Object>> page = new Page<>(1, 10);
 IPage<Map<String, Object>> userPageMaps = userService.pageMaps(page); // 调用 pageMaps 方法
 List<Map<String, Object>> userMapList = userPageMaps.getRecords();
 long total = userPageMaps.getTotal();
@@ -876,7 +876,7 @@ SELECT * FROM user LIMIT 10 OFFSET 0
 
 ```java
 // 假设有一个 QueryWrapper 对象，设置查询条件为 age > 25，进行有条件的分页查询，并将结果映射为 Map
-IPage<User> page = new Page<>(1, 10);
+IPage<Map<String, Object>> page = new Page<>(1, 10);
 QueryWrapper<User> queryWrapper = new QueryWrapper<>();
 queryWrapper.gt("age", 25);
 IPage<Map<String, Object>> userPageMaps = userService.pageMaps(page, queryWrapper); // 调用 pageMaps 方法
@@ -1360,7 +1360,7 @@ SELECT * FROM user WHERE age > 25 LIMIT 10 OFFSET 0
 
 ```java
 // 假设要进行分页查询，每页显示10条记录，查询第1页，查询条件为 age > 25，并将结果映射为 Map
-IPage<User> page = new Page<>(1, 10);
+IPage<Map<String, Object>> = new Page<>(1, 10);
 QueryWrapper<User> queryWrapper = new QueryWrapper<>();
 queryWrapper.gt("age", 25);
 IPage<Map<String, Object>> userPageMaps = userMapper.selectMapsPage(page, queryWrapper); // 调用 selectMapsPage 方法


### PR DESCRIPTION
https://github.com/baomidou/mybatis-plus/blob/fcb9cb499edfd30b26e43ffee70242e5daba12c8/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/IService.java#L545-L547
https://github.com/baomidou/mybatis-plus/blob/fcb9cb499edfd30b26e43ffee70242e5daba12c8/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/mapper/BaseMapper.java#L468-L471

The `pageMaps` method uses `BaseMapper`'s `selectMapsPage` method This method takes a page parameter of type P, where `P extends IPage<Map<String, Object>>`, so pageMaps cannot pass a parameter of type `IPage<User>`.
`pageMaps` 方法使用了 `BaseMapper` 的 `selectMapsPage` 方法 该方法接收一个P类型的page参数，其中 `P extends IPage<Map<String, Object>>` ，所以pageMaps无法传递一个 `IPage<User>` 类型的参数