### PR TITLE
add @TableName("`user`") annotation for User model

### DIFF
--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -128,6 +128,7 @@ public class Application {
 <!-- User.java -->
 
 @Data
+@TableName("`user`")
 public class User {
     private Long id;
     private String name;


### PR DESCRIPTION
"USER" is  one of the reserved words in H2, that can't be used as identifiers (table names, column names and so on), unless they are quoted (surrounded with double quotes). In this tutorial, "user" happens to be the name used in the User model object, that could cause `org.h2.jdbc.JdbcSQLSyntaxErrorException`. To avoid getting confused for some beginners , maybe we could use `@TableName("`user`")` to qualify the table name in the User model object.