### PR TITLE
Update wrapper.mdx

### DIFF
--- a/src/content/docs/guides/wrapper.mdx
+++ b/src/content/docs/guides/wrapper.mdx
@@ -2626,7 +2626,7 @@ lambda();
 QueryWrapper<User> queryWrapper = new QueryWrapper<>();
 LambdaQueryWrapper<User> lambdaQueryWrapper = queryWrapper.lambda();
 // 使用 Lambda 表达式构建查询条件
-lambdaQueryWrapper.eq("name", "张三");
+lambdaQueryWrapper.eq(User::getName, "张三");
 ```
 
 **从 UpdateWrapper 获取 LambdaUpdateWrapper**：


### PR DESCRIPTION
将字符串形式的字段引用 eq("name", "张三") 改为类型安全的方法引用 eq(User::getName, "张三")。

符合 MyBatis-Plus 设计 LambdaQueryWrapper 的初衷