### PR TITLE
快速开始教程新增 Java/Kotlin 代码切换

### DIFF
--- a/src/components/CodeLangSync.astro
+++ b/src/components/CodeLangSync.astro
@@ -1,0 +1,75 @@
+---
+// ABOUTME: Client script that keeps every Java/Kotlin code tab group on a page in
+// ABOUTME: sync and remembers the chosen language across pages via localStorage.
+---
+
+<script>
+  // Starlight 0.21.5 has no native `syncKey`, so we synchronise the Java/Kotlin
+  // code selectors ourselves. If Starlight is ever upgraded to a version with
+  // native synced tabs, this component (and the syncKey attributes in the docs)
+  // can be removed to avoid double-handling.
+  (function () {
+    const KEY = "code-lang";
+    const LANGS = ["Java", "Kotlin"];
+    let syncing = false;
+
+    // A `<starlight-tabs>` is a code-language selector when every one of its own
+    // tab labels is Java or Kotlin. This distinguishes it from other tab groups
+    // such as the Maven/Gradle dependency tabs.
+    function isCodeLangGroup(group: Element) {
+      const tabs = group.querySelectorAll(':scope > .tablist-wrapper [role="tab"]');
+      if (tabs.length === 0) return false;
+      return Array.prototype.every.call(tabs, (tab) =>
+        LANGS.includes(tab.textContent.trim())
+      );
+    }
+
+    // Activate `lang` in every code-language group except the one the user just
+    // clicked, reusing Starlight's own tab switching by clicking the anchor.
+    function applyLang(lang: string, exceptGroup: Element | null) {
+      document.querySelectorAll("starlight-tabs").forEach((group) => {
+        if (group === exceptGroup || !isCodeLangGroup(group)) return;
+        const target = Array.prototype.find.call(
+          group.querySelectorAll(':scope > .tablist-wrapper [role="tab"]'),
+          (tab) => tab.textContent.trim() === lang
+        );
+        if (target && target.getAttribute("aria-selected") !== "true") {
+          target.click();
+        }
+      });
+    }
+
+    function init() {
+      const stored = localStorage.getItem(KEY);
+      if (stored && LANGS.includes(stored)) {
+        syncing = true;
+        applyLang(stored, null);
+        syncing = false;
+      }
+    }
+
+    document.addEventListener("click", (event) => {
+      if (syncing) return;
+      const tab =
+        event.target instanceof Element && event.target.closest('a[role="tab"]');
+      if (!tab) return;
+      const group = tab.closest("starlight-tabs");
+      if (!group || !isCodeLangGroup(group)) return;
+      const lang = tab.textContent.trim();
+      if (!LANGS.includes(lang)) return;
+      localStorage.setItem(KEY, lang);
+      syncing = true;
+      applyLang(lang, group);
+      syncing = false;
+    });
+
+    // Wait until Starlight's <starlight-tabs> element is defined (and its
+    // existing instances upgraded with click handlers) before applying the
+    // stored preference, otherwise the programmatic clicks have no effect.
+    if (window.customElements) {
+      customElements.whenDefined("starlight-tabs").then(init);
+    } else {
+      window.addEventListener("load", init);
+    }
+  })();
+</script>

--- a/src/components/CodeLangSync.astro
+++ b/src/components/CodeLangSync.astro
@@ -34,10 +34,18 @@
           (tab) => tab.textContent.trim() === lang
         );
         if (target && target.getAttribute("aria-selected") !== "true") {
+          // Starlight's switchTab() ends with `newTab.focus()`, which scrolls
+          // that tab into view. That is correct for the tab the user actually
+          // clicked, but for the groups we mirror it would jump the page to
+          // whichever group we happen to sync last, so suppress it here.
+          target.focus = noop;
           target.click();
+          delete target.focus;
         }
       });
     }
+
+    function noop() {}
 
     function init() {
       const stored = localStorage.getItem(KEY);
@@ -58,9 +66,15 @@
       const lang = tab.textContent.trim();
       if (!LANGS.includes(lang)) return;
       localStorage.setItem(KEY, lang);
+      // The Java and Kotlin panels are rarely the same height, so switching the
+      // groups above this one shifts it up or down under the pointer. Keep the
+      // clicked tab visually anchored by scrolling by the same amount.
+      const before = tab.getBoundingClientRect().top;
       syncing = true;
       applyLang(lang, group);
       syncing = false;
+      const shift = tab.getBoundingClientRect().top - before;
+      if (shift) window.scrollBy({ top: shift, behavior: "instant" });
     });
 
     // Wait until Starlight's <starlight-tabs> element is defined (and its

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import type { Props } from '@astrojs/starlight/props';
 import Default from "@astrojs/starlight/components/Footer.astro";
+import CodeLangSync from "./CodeLangSync.astro";
 
 const yearText = new Date().getFullYear().toString();
 ---
@@ -8,6 +9,8 @@ const yearText = new Date().getFullYear().toString();
 <Default {...Astro.props}>
     <slot/>
 </Default>
+
+<CodeLangSync />
 
 <div class="not-content">
     <div class="text-center mt-20">

--- a/src/content/docs/en/getting-started/config.mdx
+++ b/src/content/docs/en/getting-started/config.mdx
@@ -4,6 +4,8 @@ sidebar:
   order: 3
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 Integrating MyBatis-Plus is incredibly simple! With just a few basic configuration steps, you can start leveraging the powerful features of MyBatis-Plus.
 
 :::tip
@@ -13,6 +15,9 @@ Before we dive into the configuration, please make sure you have installed MyBat
 ## Spring Boot Project
 
 - Configure the MapperScan annotation
+
+  <Tabs syncKey="code-lang">
+  <TabItem label="Java">
 
   ```java {2}
   @SpringBootApplication
@@ -25,6 +30,22 @@ Before we dive into the configuration, please make sure you have installed MyBat
 
   }
   ```
+
+  </TabItem>
+  <TabItem label="Kotlin">
+
+  ```kotlin {2}
+  @SpringBootApplication
+  @MapperScan("com.baomidou.mybatisplus.samples.quickstart.mapper")
+  class Application
+
+  fun main(args: Array<String>) {
+      runApplication<Application>(*args)
+  }
+  ```
+
+  </TabItem>
+  </Tabs>
 
 ## Spring Project
 

--- a/src/content/docs/en/getting-started/index.mdx
+++ b/src/content/docs/en/getting-started/index.mdx
@@ -4,6 +4,7 @@ sidebar:
   order: 1
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
 import LastedDependency from '@/components/LastedDependency.astro';
 
 We'll demonstrate the powerful features of MyBatis-Plus through a simple Demo. Before we begin, we assume you already have:
@@ -109,6 +110,9 @@ The configuration above contains the standard database connection settings for a
 
 Add the `@MapperScan` annotation to the Spring Boot application class to scan the Mapper package:
 
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
+
 ```java {2}
 <!-- Application.java -->
 
@@ -123,9 +127,30 @@ public class Application {
 }
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin {2}
+// Application.kt
+
+@SpringBootApplication
+@MapperScan("com.baomidou.mybatisplus.samples.quickstart.mapper")
+class Application
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}
+```
+
+</TabItem>
+</Tabs>
+
 ## Coding
 
 Create the entity class `User.java`:
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 <!-- User.java -->
@@ -140,11 +165,32 @@ public class User {
 }
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// User.kt
+
+@TableName("`user`")
+data class User(
+    var id: Long? = null,
+    var name: String? = null,
+    var age: Int? = null,
+    var email: String? = null,
+)
+```
+
+</TabItem>
+</Tabs>
+
 :::note
-The code above uses [Lombok](https://projectlombok.org/) for code generation. If you prefer not to use it, please generate the Getter/Setter methods manually.
+The Java version uses [Lombok](https://projectlombok.org/) for code generation. If you prefer not to use it, please generate the Getter/Setter methods manually. The Kotlin version uses a `data class`, so Lombok is not needed.
 :::
 
 Create the Mapper interface `UserMapper.java`:
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 public interface UserMapper extends BaseMapper<User> {
@@ -152,9 +198,22 @@ public interface UserMapper extends BaseMapper<User> {
 }
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+interface UserMapper : BaseMapper<User>
+```
+
+</TabItem>
+</Tabs>
+
 ## Start Using
 
 Add a test class for functionality testing:
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 @SpringBootTest
@@ -173,6 +232,30 @@ public class SampleTest {
 
 }
 ```
+
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+@SpringBootTest
+class SampleTest {
+
+    @Autowired
+    lateinit var userMapper: UserMapper
+
+    @Test
+    fun testSelect() {
+        println("----- selectAll method test ------")
+        val userList = userMapper.selectList(null)
+        Assert.isTrue(userList.size == 5, "")
+        userList.forEach { println(it) }
+    }
+
+}
+```
+
+</TabItem>
+</Tabs>
 
 :::tip
 The parameter for the `selectList()` method in UserMapper is MP's built-in conditional wrapper `Wrapper`, so passing `null` means no conditions are applied.

--- a/src/content/docs/en/getting-started/index.mdx
+++ b/src/content/docs/en/getting-started/index.mdx
@@ -174,9 +174,9 @@ public class User {
 @TableName("`user`")
 data class User(
     var id: Long? = null,
-    var name: String? = null,
-    var age: Int? = null,
-    var email: String? = null,
+    var name: String,
+    var age: Int,
+    var email: String,
 )
 ```
 

--- a/src/content/docs/en/getting-started/test.mdx
+++ b/src/content/docs/en/getting-started/test.mdx
@@ -4,7 +4,7 @@ sidebar:
   order: 4
 ---
 
-import { Steps, LinkCard } from '@astrojs/starlight/components';
+import { Steps, LinkCard, Tabs, TabItem } from '@astrojs/starlight/components';
 import LastedDependency from '@/components/LastedDependency.astro';
 
 Automatically imports the required configurations for MyBatis-Plus testing. Quickly configure test classes using the `@MybatisPlusTest` annotation.
@@ -26,6 +26,9 @@ Automatically imports the required configurations for MyBatis-Plus testing. Quic
 
     2. Write test cases
 
+        <Tabs syncKey="code-lang">
+        <TabItem label="Java">
+
         ```java
         import org.junit.jupiter.api.Test;
         import org.springframework.beans.factory.annotation.Autowired;
@@ -46,5 +49,31 @@ Automatically imports the required configurations for MyBatis-Plus testing. Quic
             }
         }
         ```
+
+        </TabItem>
+        <TabItem label="Kotlin">
+
+        ```kotlin
+        import org.junit.jupiter.api.Test
+        import org.springframework.beans.factory.annotation.Autowired
+        import org.assertj.core.api.Assertions.assertThat
+
+        @MybatisPlusTest
+        class MybatisPlusSampleTest {
+
+            @Autowired
+            lateinit var sampleMapper: SampleMapper
+
+            @Test
+            fun testInsert() {
+                val sample = Sample()
+                sampleMapper.insert(sample)
+                assertThat(sample.id).isNotNull()
+            }
+        }
+        ```
+
+        </TabItem>
+        </Tabs>
 
 </Steps>

--- a/src/content/docs/getting-started/config.mdx
+++ b/src/content/docs/getting-started/config.mdx
@@ -4,6 +4,8 @@ sidebar:
   order: 3
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 集成 MyBatis-Plus 非常的简单，我们仅需要一些简单的配置即可使用 MyBatis-Plus 的强大功能！
 
 :::tip
@@ -13,6 +15,9 @@ sidebar:
 ## Spring Boot 工程
 
 - 配置 MapperScan 注解
+
+  <Tabs syncKey="code-lang">
+  <TabItem label="Java">
 
   ```java {2}
   @SpringBootApplication
@@ -25,6 +30,22 @@ sidebar:
 
   }
   ```
+
+  </TabItem>
+  <TabItem label="Kotlin">
+
+  ```kotlin {2}
+  @SpringBootApplication
+  @MapperScan("com.baomidou.mybatisplus.samples.quickstart.mapper")
+  class Application
+
+  fun main(args: Array<String>) {
+      runApplication<Application>(*args)
+  }
+  ```
+
+  </TabItem>
+  </Tabs>
 
 ## Spring 工程
 

--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -175,9 +175,9 @@ public class User {
 @TableName("`user`")
 data class User(
     var id: Long? = null,
-    var name: String? = null,
-    var age: Int? = null,
-    var email: String? = null,
+    var name: String,
+    var age: Int,
+    var email: String,
 )
 ```
 

--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
 import LastedDependency from '@/components/LastedDependency.astro';
 
 我们将通过一个简单的 Demo 来阐述 MyBatis-Plus 的强大功能，在此之前，我们假设您已经：
@@ -110,6 +111,9 @@ spring:
 
 在 Spring Boot 启动类中添加 `@MapperScan` 注解，扫描 Mapper 文件夹：
 
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
+
 ```java {2}
 <!-- Application.java -->
 
@@ -124,9 +128,30 @@ public class Application {
 }
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin {2}
+// Application.kt
+
+@SpringBootApplication
+@MapperScan("com.baomidou.mybatisplus.samples.quickstart.mapper")
+class Application
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}
+```
+
+</TabItem>
+</Tabs>
+
 ## 编码
 
 编写实体类 `User.java`：
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 <!-- User.java -->
@@ -141,12 +166,33 @@ public class User {
 }
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// User.kt
+
+@TableName("`user`")
+data class User(
+    var id: Long? = null,
+    var name: String? = null,
+    var age: Int? = null,
+    var email: String? = null,
+)
+```
+
+</TabItem>
+</Tabs>
+
 :::note
-上面的代码中使用了 [Lombok](https://projectlombok.org/) 进行代码生成，如果您不习惯，请自行生成相关 Getter/Setter 方法。
+Java 版本使用了 [Lombok](https://projectlombok.org/) 进行代码生成，如果您不习惯，请自行生成相关 Getter/Setter 方法。Kotlin 版本使用 `data class`，无需 Lombok。
 :::
 
 
 编写 Mapper 接口类 `UserMapper.java`：
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 public interface UserMapper extends BaseMapper<User> {
@@ -154,9 +200,22 @@ public interface UserMapper extends BaseMapper<User> {
 }
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+interface UserMapper : BaseMapper<User>
+```
+
+</TabItem>
+</Tabs>
+
 ## 开始使用
 
 添加测试类，进行功能测试：
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 @SpringBootTest
@@ -175,6 +234,30 @@ public class SampleTest {
 
 }
 ```
+
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+@SpringBootTest
+class SampleTest {
+
+    @Autowired
+    lateinit var userMapper: UserMapper
+
+    @Test
+    fun testSelect() {
+        println("----- selectAll method test ------")
+        val userList = userMapper.selectList(null)
+        Assert.isTrue(userList.size == 5, "")
+        userList.forEach { println(it) }
+    }
+
+}
+```
+
+</TabItem>
+</Tabs>
 
 :::tip
 UserMapper 中的 `selectList()` 方法的参数为 MP 内置的条件封装器 `Wrapper`，所以不填写就是无任何条件

--- a/src/content/docs/getting-started/test.mdx
+++ b/src/content/docs/getting-started/test.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 4
 ---
 
-import { Steps, LinkCard } from '@astrojs/starlight/components';
+import { Steps, LinkCard, Tabs, TabItem } from '@astrojs/starlight/components';
 import LastedDependency from '@/components/LastedDependency.astro';
 
 自动导入 MyBatis-Plus 测试所需相关配置，通过 `@MybatisPlusTest` 注解快速配置测试类。
@@ -28,6 +28,9 @@ import LastedDependency from '@/components/LastedDependency.astro';
 
     2. 编写测试用例
 
+        <Tabs syncKey="code-lang">
+        <TabItem label="Java">
+
         ```java
         import org.junit.jupiter.api.Test;
         import org.springframework.beans.factory.annotation.Autowired;
@@ -48,5 +51,31 @@ import LastedDependency from '@/components/LastedDependency.astro';
             }
         }
         ```
+
+        </TabItem>
+        <TabItem label="Kotlin">
+
+        ```kotlin
+        import org.junit.jupiter.api.Test
+        import org.springframework.beans.factory.annotation.Autowired
+        import org.assertj.core.api.Assertions.assertThat
+
+        @MybatisPlusTest
+        class MybatisPlusSampleTest {
+
+            @Autowired
+            lateinit var sampleMapper: SampleMapper
+
+            @Test
+            fun testInsert() {
+                val sample = Sample()
+                sampleMapper.insert(sample)
+                assertThat(sample.id).isNotNull()
+            }
+        }
+        ```
+
+        </TabItem>
+        </Tabs>
 
 </Steps>

--- a/src/content/docs/ja/getting-started/config.mdx
+++ b/src/content/docs/ja/getting-started/config.mdx
@@ -4,6 +4,8 @@ sidebar:
   order: 3
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 MyBatis-Plus の統合は非常に簡単で、いくつかの簡単な設定だけで MyBatis-Plus の強力な機能を使用できます！
 
 :::tip
@@ -13,6 +15,9 @@ MyBatis-Plus の統合は非常に簡単で、いくつかの簡単な設定だ�
 ## Spring Boot プロジェクト
 
 - MapperScan アノテーションの設定
+
+  <Tabs syncKey="code-lang">
+  <TabItem label="Java">
 
   ```java {2}
   @SpringBootApplication
@@ -25,6 +30,22 @@ MyBatis-Plus の統合は非常に簡単で、いくつかの簡単な設定だ�
 
   }
   ```
+
+  </TabItem>
+  <TabItem label="Kotlin">
+
+  ```kotlin {2}
+  @SpringBootApplication
+  @MapperScan("com.baomidou.mybatisplus.samples.quickstart.mapper")
+  class Application
+
+  fun main(args: Array<String>) {
+      runApplication<Application>(*args)
+  }
+  ```
+
+  </TabItem>
+  </Tabs>
 
 ## Spring プロジェクト
 

--- a/src/content/docs/ja/getting-started/index.mdx
+++ b/src/content/docs/ja/getting-started/index.mdx
@@ -4,6 +4,7 @@ sidebar:
   order: 1
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
 import LastedDependency from '@/components/LastedDependency.astro';
 
 このシンプルなデモを通じて、MyBatis-Plusの強力な機能について説明します。その前に、以下の前提条件を満たしていることを想定しています：
@@ -109,6 +110,9 @@ spring:
 
 Spring Boot起動クラスに `@MapperScan` アノテーションを追加し、Mapperフォルダをスキャンします：
 
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
+
 ```java {2}
 <!-- Application.java -->
 
@@ -123,9 +127,30 @@ public class Application {
 }
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin {2}
+// Application.kt
+
+@SpringBootApplication
+@MapperScan("com.baomidou.mybatisplus.samples.quickstart.mapper")
+class Application
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}
+```
+
+</TabItem>
+</Tabs>
+
 ## コーディング
 
 エンティティクラス `User.java` を作成します：
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 <!-- User.java -->
@@ -140,11 +165,32 @@ public class User {
 }
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// User.kt
+
+@TableName("`user`")
+data class User(
+    var id: Long? = null,
+    var name: String? = null,
+    var age: Int? = null,
+    var email: String? = null,
+)
+```
+
+</TabItem>
+</Tabs>
+
 :::note
-上記のコードでは、コード生成に [Lombok](https://projectlombok.org/) を使用しています。慣れていない場合は、関連するGetter/Setterメソッドを自行で生成してください。
+Java 版本ではコード生成に [Lombok](https://projectlombok.org/) を使用しています。慣れていない場合は、関連するGetter/Setterメソッドを自行で生成してください。Kotlin 版本では `data class` を使用するため、Lombok は不要です。
 :::
 
 Mapperインターフェースクラス `UserMapper.java` を作成します：
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 public interface UserMapper extends BaseMapper<User> {
@@ -152,9 +198,22 @@ public interface UserMapper extends BaseMapper<User> {
 }
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+interface UserMapper : BaseMapper<User>
+```
+
+</TabItem>
+</Tabs>
+
 ## 使用方法
 
 テストクラスを追加して、機能テストを実行します：
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 @SpringBootTest
@@ -173,6 +232,30 @@ public class SampleTest {
 
 }
 ```
+
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+@SpringBootTest
+class SampleTest {
+
+    @Autowired
+    lateinit var userMapper: UserMapper
+
+    @Test
+    fun testSelect() {
+        println("----- selectAll method test ------")
+        val userList = userMapper.selectList(null)
+        Assert.isTrue(userList.size == 5, "")
+        userList.forEach { println(it) }
+    }
+
+}
+```
+
+</TabItem>
+</Tabs>
 
 :::tip
 UserMapperの `selectList()` メソッドのパラメータは、MP組み込みの条件ラッパー `Wrapper` であるため、何も記述しないと条件なしとなります

--- a/src/content/docs/ja/getting-started/index.mdx
+++ b/src/content/docs/ja/getting-started/index.mdx
@@ -174,9 +174,9 @@ public class User {
 @TableName("`user`")
 data class User(
     var id: Long? = null,
-    var name: String? = null,
-    var age: Int? = null,
-    var email: String? = null,
+    var name: String,
+    var age: Int,
+    var email: String,
 )
 ```
 

--- a/src/content/docs/ja/getting-started/test.mdx
+++ b/src/content/docs/ja/getting-started/test.mdx
@@ -4,7 +4,7 @@ sidebar:
   order: 4
 ---
 
-import { Steps, LinkCard } from '@astrojs/starlight/components';
+import { Steps, LinkCard, Tabs, TabItem } from '@astrojs/starlight/components';
 import LastedDependency from '@/components/LastedDependency.astro';
 
 MyBatis-Plusのテストに必要な関連設定を自動インポートし、`@MybatisPlusTest`アノテーションを使用してテストクラスを迅速に設定します。
@@ -27,6 +27,9 @@ MyBatis-Plusのテストに必要な関連設定を自動インポートし、`@
 
     2. テストケースを作成
 
+        <Tabs syncKey="code-lang">
+        <TabItem label="Java">
+
         ```java
         import org.junit.jupiter.api.Test;
         import org.springframework.beans.factory.annotation.Autowired;
@@ -47,5 +50,31 @@ MyBatis-Plusのテストに必要な関連設定を自動インポートし、`@
             }
         }
         ```
+
+        </TabItem>
+        <TabItem label="Kotlin">
+
+        ```kotlin
+        import org.junit.jupiter.api.Test
+        import org.springframework.beans.factory.annotation.Autowired
+        import org.assertj.core.api.Assertions.assertThat
+
+        @MybatisPlusTest
+        class MybatisPlusSampleTest {
+
+            @Autowired
+            lateinit var sampleMapper: SampleMapper
+
+            @Test
+            fun testInsert() {
+                val sample = Sample()
+                sampleMapper.insert(sample)
+                assertThat(sample.id).isNotNull()
+            }
+        }
+        ```
+
+        </TabItem>
+        </Tabs>
 
 </Steps>


### PR DESCRIPTION
## 说明

为快速开始教程（初始化工程 / 配置 / 开始使用）中的代码示例添加 Java/Kotlin 切换标签，覆盖中、英、日三个语言版本：

- 每段 Java 示例配有等价的 Kotlin 示例，通过 `<Tabs>` 切换；
- 选择的语言会在页面内所有代码组之间联动，并通过 localStorage 跨页面记忆（Starlight 0.21.5 无原生 `syncKey`，由新增的 `CodeLangSync.astro` 组件实现，升级 Starlight 后可移除）；
- `config.md` 重命名为 `config.mdx` 以支持组件，URL 不变。

## English summary

Adds a synced Java/Kotlin code selector to the Getting Started tutorial (quick start, config, test pages) in all three locales. Language choice syncs across all code groups on a page and persists across pages via localStorage; implemented in a small `CodeLangSync.astro` client script since Starlight 0.21.5 lacks native `syncKey`. `config.md` renamed to `config.mdx` (routed URL unchanged).

`npm run build` (astro check + build) passes: 153 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)