### PR TITLE
更新 Kotlin 文档：3.5.17 起 Lambda Wrapper 支持 Kotlin

### DIFF
--- a/src/content/docs/en/guides/data-interface.mdx
+++ b/src/content/docs/en/guides/data-interface.mdx
@@ -3,6 +3,9 @@ title: Persistence Layer Interface
 sidebar:
   order: 3
 ---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
 This document provides a comprehensive overview of various persistence operations using MyBatis-Plus, including insertion, update, deletion, query, and pagination. Through this guide, you will learn how the different methods provided by MyBatis-Plus perform data operations and see the corresponding SQL statements they generate.
 
 ## Service Interface
@@ -1442,7 +1445,7 @@ By using these optional components, you can further extend MyBatis-Plus's capabi
 
 ## Chain
 
-Chain is a chain programming style provided by MyBatis-Plus that allows you to write database operation code in a more concise and intuitive way. Chain is divided into two main categories: `query` and `update`, used for query and update operations respectively. Each category is further divided into regular chain style and lambda chain style. The lambda chain style provides type-safe query condition construction but does not support Kotlin.
+Chain is a chain programming style provided by MyBatis-Plus that allows you to write database operation code in a more concise and intuitive way. Chain is divided into two main categories: `query` and `update`, used for query and update operations respectively. Each category is further divided into regular chain style and lambda chain style. The lambda chain style provides type-safe query condition construction and, since `3.5.17`, also supports Kotlin (on earlier versions, `KtQueryChainWrapper`/`KtUpdateChainWrapper` can be used from Kotlin).
 
 ### Usage Steps
 
@@ -1453,11 +1456,14 @@ Provides chain-style query operations, allowing you to chain method calls to bui
 ```java
 // Chain-style query (standard)
 QueryChainWrapper<T> query();
-// Chain-style query (lambda). Note: Kotlin is not supported
+// Chain-style query (lambda; supports Kotlin since 3.5.17)
 LambdaQueryChainWrapper<T> lambdaQuery();
 ```
 
 **Example**:
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 // Standard chain-style query example
@@ -1467,6 +1473,20 @@ query().eq("name", "John").list(); // Query all records where name equals "John"
 lambdaQuery().eq(User::getAge, 30).one(); // Query a single record where age equals 30
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// Standard chain-style query example
+query().eq("name", "John").list() // Query all records where name equals "John"
+
+// Lambda chain-style query example (3.5.17+)
+lambdaQuery().eq(User::age, 30).one() // Query a single record where age equals 30
+```
+
+</TabItem>
+</Tabs>
+
 #### update
 
 Provides chain-style update operations, allowing you to chain method calls to build update conditions.
@@ -1474,11 +1494,14 @@ Provides chain-style update operations, allowing you to chain method calls to bu
 ```java
 // Chain-style update (standard)
 UpdateChainWrapper<T> update();
-// Chain-style update (lambda). Note: Kotlin is not supported
+// Chain-style update (lambda; supports Kotlin since 3.5.17)
 LambdaUpdateChainWrapper<T> lambdaUpdate();
 ```
 
 **Example**:
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 // Standard chain-style update example
@@ -1489,6 +1512,20 @@ User updateUser = new User();
 updateUser.setEmail("new.email@example.com");
 lambdaUpdate().set(User::getEmail, updateUser.getEmail()).eq(User::getId, 1).update(); // Update the email for the user with ID 1
 ```
+
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// Standard chain-style update example
+update().set("status", "inactive").eq("name", "John").update() // Update the status to "inactive" for records where name equals "John"
+
+// Lambda chain-style update example (3.5.17+)
+lambdaUpdate().set(User::email, "new.email@example.com").eq(User::id, 1).update() // Update the email for the user with ID 1
+```
+
+</TabItem>
+</Tabs>
 
 ### Usage Tips
 

--- a/src/content/docs/en/guides/wrapper.mdx
+++ b/src/content/docs/en/guides/wrapper.mdx
@@ -4,6 +4,7 @@ sidebar:
   order: 4
 ---
 import Badge from "@/components/Badge.astro";
+import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 MyBatis-Plus provides a powerful set of conditional constructors (Wrapper) for building complex database query conditions. The Wrapper classes allow developers to construct query conditions using a chainable method call approach, eliminating the need to write verbose SQL statements. This improves development efficiency and reduces the risk of SQL injection.
 
@@ -2783,7 +2784,7 @@ class User {
 
 **Note**: The `@TableId` and `@TableField` annotations in the code above are used to demonstrate MyBatis-Plus usage and are not mandatory. All member variables should be defined as nullable types with initial values of `null` to support scenarios like Java's `updateSelective` operations.
 
-Avoid using `data class` or full-parameter constructors, as they may require you to provide unnecessary `null` values when creating empty objects.
+Avoid using `data class` or full-parameter constructors, as they may require you to provide unnecessary `null` values when creating empty objects. If all properties are nullable `var`s with default values (as in the Quick Start tutorial), Kotlin generates a no-argument constructor and a `data class` works fine; this recommendation mainly targets full-parameter constructors without defaults.
 
 ### Using Annotations for Queries
 
@@ -2806,33 +2807,59 @@ List<MysqlData> getAll(Wrapper ew);
 
 ### Using Wrapper in Kotlin
 
-Kotlin supports `QueryWrapper` and `UpdateWrapper`, but does not support `LambdaQueryWrapper` and `LambdaUpdateWrapper`. If you need to use Lambda-style Wrappers, you can use `KtQueryWrapper` and `KtUpdateWrapper`.
+All Wrappers can be used in Kotlin:
 
-Reference example:
+- `QueryWrapper` and `UpdateWrapper` (string column names) work in all versions.
+- `KtQueryWrapper` and `KtUpdateWrapper` are the Kotlin-specific Lambda-style Wrappers based on `KProperty` property references (such as `User::name`) and work in all versions.
+- Since `3.5.17`, `LambdaQueryWrapper` and `LambdaUpdateWrapper` also support Kotlin — both Kotlin property references (`User::name`) and Java getter method references resolve correctly. On earlier versions, use `KtQueryWrapper`/`KtUpdateWrapper` from Kotlin.
+
+`KtQueryWrapper`/`KtUpdateWrapper` reference example (all versions):
 
 ```kotlin
 val queryWrapper = KtQueryWrapper(User()).eq(User::name, "sss").eq(User::roleId, "sss2")
-userMapper!!.selectList(queryWrapper)
+userMapper.selectList(queryWrapper)
 
 val updateConditionWrapper = KtUpdateWrapper(User()).eq(User::name, "sss").eq(User::roleId, "sss2")
 val updateRecord = User()
 updateRecord.name = "newName"
-userMapper!!.update(updateRecord, updateConditionWrapper)
+userMapper.update(updateRecord, updateConditionWrapper)
 
-val updateRecord = User()
-updateRecord.id = 2
-updateRecord.name = "haha"
-userMapper.updateById(updateRecord)
+val newRecord = User()
+newRecord.id = 2
+newRecord.name = "haha"
+userMapper.updateById(newRecord)
 ```
+
+`LambdaQueryWrapper`/`LambdaUpdateWrapper` reference example (`3.5.17`+):
+
+```kotlin
+val users = userMapper.selectList(LambdaQueryWrapper(User::class.java).eq(User::name, "sss"))
+
+userMapper.update(
+    null,
+    LambdaUpdateWrapper(User::class.java).set(User::name, "newName").eq(User::roleId, "sss2")
+)
+```
+
+:::note
+- On versions below `3.5.17`, using `LambdaQueryWrapper` and other Lambda-style Wrappers from Kotlin fails at runtime with an exception like `Error parsing property name 'xxx$lambda$0'. Didn't start with 'is', 'get' or 'set'.`
+- MyBatis-Plus `3.5.17` is compiled with Kotlin `2.4.0`; Kotlin projects need a Kotlin compiler of version `2.3` or above to read its Kotlin metadata.
+- In Kotlin code compiled with the `-Xsam-conversions=class` option, Java getter method references still cannot be resolved.
+:::
+
+See [mybatis-plus-sample-kotlin](https://github.com/baomidou/mybatis-plus-samples/tree/master/mybatis-plus-sample-kotlin) for a complete runnable example.
 
 ### Chained Calls and Lambda Calls
 
-MyBatis-Plus provides two styles of chained calls: regular chained calls and lambda chained calls. Note that lambda chained calls do not support Kotlin.
+MyBatis-Plus provides two styles of chained calls: regular chained calls and lambda chained calls. Since `3.5.17`, lambda chained calls also support Kotlin; on earlier versions, `KtQueryChainWrapper` and `KtUpdateChainWrapper` can be used from Kotlin.
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 // Regular chained call
 UpdateChainWrapper<T> update();
-// Lambda chained call (does not support Kotlin)
+// Lambda chained call
 LambdaUpdateChainWrapper<T> lambdaUpdate();
 
 // Equivalent examples:
@@ -2843,5 +2870,23 @@ lambdaQuery().eq(Entity::getId, value).one();
 update().eq("id", value).remove();
 lambdaUpdate().eq(Entity::getId, value).remove();
 ```
+
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// Regular chained call
+QueryChainWrapper(userMapper).eq("name", "Jack").list()
+
+// Lambda chained call (3.5.17+)
+LambdaQueryChainWrapper(userMapper).eq(User::name, "Jack").one()
+LambdaUpdateChainWrapper(userMapper).set(User::name, "newName").eq(User::name, "Jack").update()
+
+// KProperty-style chained call (all versions)
+KtQueryChainWrapper(userMapper, User::class.java).eq(User::name, "Jack").one()
+```
+
+</TabItem>
+</Tabs>
 
 By following these best practices, you can ensure that your persistence object definitions in Kotlin are both clear and maintainable, while fully leveraging the capabilities provided by MyBatis-Plus.

--- a/src/content/docs/guides/data-interface.mdx
+++ b/src/content/docs/guides/data-interface.mdx
@@ -4,6 +4,8 @@ sidebar:
   order: 3
 ---
 
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
 本文详细介绍了 MyBatis-Plus 进行持久化操作的各种方法，包括插入、更新、删除、查询和分页等。通过本文，您可以了解到 MyBatis-Plus 提供的各种方法是如何进行数据操作的，以及它们对应的 SQL 语句。
 
 ## Repository Interface
@@ -1449,7 +1451,7 @@ int logicDeleteByIdWithFill(T entity);
 
 ## Chain
 
-Chain 是 Mybatis-Plus 提供的一种链式编程风格，它允许开发者以更加简洁和直观的方式编写数据库操作代码。Chain 分为 `query` 和 `update` 两大类，分别用于查询和更新操作。每类又分为普通链式和 lambda 链式两种风格，其中 lambda 链式提供了类型安全的查询条件构造，但不支持 Kotlin。
+Chain 是 Mybatis-Plus 提供的一种链式编程风格，它允许开发者以更加简洁和直观的方式编写数据库操作代码。Chain 分为 `query` 和 `update` 两大类，分别用于查询和更新操作。每类又分为普通链式和 lambda 链式两种风格，其中 lambda 链式提供了类型安全的查询条件构造，自 `3.5.17` 起同样支持 Kotlin（更早版本的 Kotlin 下可使用 `KtQueryChainWrapper`/`KtUpdateChainWrapper`）。
 
 ### 使用步骤
 
@@ -1460,11 +1462,14 @@ Chain 是 Mybatis-Plus 提供的一种链式编程风格，它允许开发者以
 ```java
 // 链式查询 普通
 QueryChainWrapper<T> query();
-// 链式查询 lambda 式。注意：不支持 Kotlin
+// 链式查询 lambda 式（自 3.5.17 起支持 Kotlin）
 LambdaQueryChainWrapper<T> lambdaQuery();
 ```
 
 **示例**:
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 // 普通链式查询示例
@@ -1474,6 +1479,20 @@ query().eq("name", "John").list(); // 查询 name 为 "John" 的所有记录
 lambdaQuery().eq(User::getAge, 30).one(); // 查询年龄为 30 的单条记录
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// 普通链式查询示例
+query().eq("name", "John").list() // 查询 name 为 "John" 的所有记录
+
+// lambda 链式查询示例（3.5.17+）
+lambdaQuery().eq(User::age, 30).one() // 查询年龄为 30 的单条记录
+```
+
+</TabItem>
+</Tabs>
+
 #### update
 
 提供链式更新操作，可以连续调用方法来构建更新条件。
@@ -1481,11 +1500,14 @@ lambdaQuery().eq(User::getAge, 30).one(); // 查询年龄为 30 的单条记录
 ```java
 // 链式更改 普通
 UpdateChainWrapper<T> update();
-// 链式更改 lambda 式。注意：不支持 Kotlin
+// 链式更改 lambda 式（自 3.5.17 起支持 Kotlin）
 LambdaUpdateChainWrapper<T> lambdaUpdate();
 ```
 
 **示例**:
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 // 普通链式更新示例
@@ -1496,6 +1518,20 @@ User updateUser = new User();
 updateUser.setEmail("new.email@example.com");
 lambdaUpdate().set(User::getEmail, updateUser.getEmail()).eq(User::getId, 1).update(); // 更新 ID 为 1 的用户的邮箱
 ```
+
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// 普通链式更新示例
+update().set("status", "inactive").eq("name", "John").update() // 将 name 为 "John" 的记录 status 更新为 "inactive"
+
+// lambda 链式更新示例（3.5.17+）
+lambdaUpdate().set(User::email, "new.email@example.com").eq(User::id, 1).update() // 更新 ID 为 1 的用户的邮箱
+```
+
+</TabItem>
+</Tabs>
 
 ### 使用提示
 

--- a/src/content/docs/guides/wrapper.mdx
+++ b/src/content/docs/guides/wrapper.mdx
@@ -5,6 +5,7 @@ sidebar:
 ---
 
 import Badge from "@/components/Badge.astro";
+import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 MyBatis-Plus 提供了一套强大的条件构造器（Wrapper），用于构建复杂的数据库查询条件。Wrapper 类允许开发者以链式调用的方式构造查询条件，无需编写繁琐的 SQL 语句，从而提高开发效率并减少 SQL 注入的风险。
 
@@ -2839,7 +2840,7 @@ class User {
 
 **注意**：上述代码中的`@TableId`和`@TableField`注解是为了展示MyBatis-Plus的使用，并非必须。所有成员变量都应定义为可空类型，并赋予初始值`null`，以便在类似Java中的`updateSelective`场景中使用。
 
-不推荐使用`data class`或全参数构造方法，因为这可能导致在创建空对象时需要提供不必要的`null`值。
+不推荐使用`data class`或全参数构造方法，因为这可能导致在创建空对象时需要提供不必要的`null`值。若所有属性均为可空的`var`且带有默认值（如快速开始教程中的示例），Kotlin 会生成无参构造方法，此时使用`data class`也是可行的；该建议主要针对没有默认值的全参数构造方法。
 
 ### 使用注解查询
 
@@ -2862,33 +2863,59 @@ List<MysqlData> getAll(Wrapper ew);
 
 ### Kotlin中使用Wrapper
 
-Kotlin支持`QueryWrapper`和`UpdateWrapper`，但不支持`LambdaQueryWrapper`和`LambdaUpdateWrapper`。如果需要使用Lambda风格的Wrapper，可以使用`KtQueryWrapper`和`KtUpdateWrapper`。
+Kotlin中可以使用全部的Wrapper：
 
-参考示例：
+- `QueryWrapper`和`UpdateWrapper`（字符串列名）在所有版本中均可使用。
+- `KtQueryWrapper`和`KtUpdateWrapper`基于`KProperty`属性引用（如`User::name`），是Kotlin专属的Lambda风格Wrapper，在所有版本中均可使用。
+- 自`3.5.17`起，`LambdaQueryWrapper`和`LambdaUpdateWrapper`同样支持Kotlin，Kotlin属性引用（`User::name`）与Java getter方法引用均可正确解析；在更早的版本中，Kotlin下请使用`KtQueryWrapper`/`KtUpdateWrapper`。
+
+`KtQueryWrapper`/`KtUpdateWrapper`参考示例（所有版本可用）：
 
 ```kotlin
 val queryWrapper = KtQueryWrapper(User()).eq(User::name, "sss").eq(User::roleId, "sss2")
-userMapper!!.selectList(queryWrapper)
+userMapper.selectList(queryWrapper)
 
 val updateConditionWrapper = KtUpdateWrapper(User()).eq(User::name, "sss").eq(User::roleId, "sss2")
 val updateRecord = User()
 updateRecord.name = "newName"
-userMapper!!.update(updateRecord, updateConditionWrapper)
+userMapper.update(updateRecord, updateConditionWrapper)
 
-val updateRecord = User()
-updateRecord.id = 2
-updateRecord.name = "haha"
-userMapper.updateById(updateRecord)
+val newRecord = User()
+newRecord.id = 2
+newRecord.name = "haha"
+userMapper.updateById(newRecord)
 ```
+
+`LambdaQueryWrapper`/`LambdaUpdateWrapper`参考示例（`3.5.17`+）：
+
+```kotlin
+val users = userMapper.selectList(LambdaQueryWrapper(User::class.java).eq(User::name, "sss"))
+
+userMapper.update(
+    null,
+    LambdaUpdateWrapper(User::class.java).set(User::name, "newName").eq(User::roleId, "sss2")
+)
+```
+
+:::note
+- 在低于`3.5.17`的版本中，Kotlin下使用`LambdaQueryWrapper`等Lambda风格Wrapper会在运行时抛出类似`Error parsing property name 'xxx$lambda$0'. Didn't start with 'is', 'get' or 'set'.`的异常。
+- MyBatis-Plus `3.5.17`使用Kotlin `2.4.0`编译，Kotlin项目需使用`2.3`及以上版本的Kotlin编译器才能读取其Kotlin元数据。
+- 使用`-Xsam-conversions=class`编译选项构建的Kotlin代码中，Java getter方法引用仍无法解析。
+:::
+
+完整可运行示例参见 [mybatis-plus-sample-kotlin](https://github.com/baomidou/mybatis-plus-samples/tree/master/mybatis-plus-sample-kotlin)。
 
 ### 链式调用与Lambda式调用
 
-MyBatis-Plus提供了两种风格的链式调用：普通链式调用和Lambda式链式调用。需要注意的是，Lambda式链式调用不支持Kotlin。
+MyBatis-Plus提供了两种风格的链式调用：普通链式调用和Lambda式链式调用。自`3.5.17`起，Lambda式链式调用同样支持Kotlin；在更早的版本中，Kotlin下可使用`KtQueryChainWrapper`和`KtUpdateChainWrapper`。
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 // 普通链式调用
 UpdateChainWrapper<T> update();
-// Lambda式链式调用（不支持Kotlin）
+// Lambda式链式调用
 LambdaUpdateChainWrapper<T> lambdaUpdate();
 
 // 等价示例：
@@ -2899,5 +2926,23 @@ lambdaQuery().eq(Entity::getId, value).one();
 update().eq("id", value).remove();
 lambdaUpdate().eq(Entity::getId, value).remove();
 ```
+
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// 普通链式调用
+QueryChainWrapper(userMapper).eq("name", "Jack").list()
+
+// Lambda式链式调用（3.5.17+）
+LambdaQueryChainWrapper(userMapper).eq(User::name, "Jack").one()
+LambdaUpdateChainWrapper(userMapper).set(User::name, "newName").eq(User::name, "Jack").update()
+
+// KProperty风格链式调用（所有版本可用）
+KtQueryChainWrapper(userMapper, User::class.java).eq(User::name, "Jack").one()
+```
+
+</TabItem>
+</Tabs>
 
 通过遵循这些最佳实践，我们可以确保Kotlin中的持久化对象定义既清晰又易于维护，同时充分利用MyBatis-Plus提供的功能。

--- a/src/content/docs/ja/guides/data-interface.mdx
+++ b/src/content/docs/ja/guides/data-interface.mdx
@@ -3,6 +3,9 @@ title: 永続化レイヤーインターフェース
 sidebar:
   order: 3
 ---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
 本文では、MyBatis-Plus を使用した永続化操作の各種メソッドについて詳しく説明します。挿入、更新、削除、検索、ページネーションなどを含みます。本稿を通じて、MyBatis-Plus が提供する各種メソッドがどのようにデータ操作を行うか、およびそれらに対応する SQL 文について理解することができます。
 
 ## Service インターフェース
@@ -1441,7 +1444,7 @@ int logicDeleteByIdWithFill(T entity);
 
 ## Chain
 
-Chain は MyBatis-Plus が提供するチェーンプログラミングスタイルであり、開発者がより簡潔で直感的な方法でデータベース操作コードを記述できるようにします。Chain は `query` と `update` の 2 つのカテゴリに分かれており、それぞれ検索操作と更新操作に使用されます。各カテゴリはさらに、通常のチェーンスタイルとラムダチェーンスタイルの 2 つのスタイルに分かれており、ラムダチェーンスタイルは型安全な検索条件構築を提供しますが、Kotlin には対応していません。
+Chain は MyBatis-Plus が提供するチェーンプログラミングスタイルであり、開発者がより簡潔で直感的な方法でデータベース操作コードを記述できるようにします。Chain は `query` と `update` の 2 つのカテゴリに分かれており、それぞれ検索操作と更新操作に使用されます。各カテゴリはさらに、通常のチェーンスタイルとラムダチェーンスタイルの 2 つのスタイルに分かれており、ラムダチェーンスタイルは型安全な検索条件構築を提供し、`3.5.17` 以降は Kotlin にも対応しています（それより前のバージョンでは、Kotlin から `KtQueryChainWrapper`/`KtUpdateChainWrapper` を使用できます）。
 
 ### 使用手順
 
@@ -1452,11 +1455,14 @@ Chain は MyBatis-Plus が提供するチェーンプログラミングスタイ
 ```java
 // 链式查询 普通
 QueryChainWrapper<T> query();
-// 链式查询 lambda 式。注意：不支持 Kotlin
+// 链式查询 lambda 式（3.5.17 以降 Kotlin に対応）
 LambdaQueryChainWrapper<T> lambdaQuery();
 ```
 
 **使用例**:
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 // 通常のチェーン式クエリの例
@@ -1466,6 +1472,20 @@ query().eq("name", "John").list(); // name が "John" であるすべてのレ�
 lambdaQuery().eq(User::getAge, 30).one(); // 年齢が 30 の単一レコードを検索
 ```
 
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// 通常のチェーン式クエリの例
+query().eq("name", "John").list() // name が "John" であるすべてのレコードを検索
+
+// lambda チェーン式クエリの例（3.5.17+）
+lambdaQuery().eq(User::age, 30).one() // 年齢が 30 の単一レコードを検索
+```
+
+</TabItem>
+</Tabs>
+
 #### update
 
 チェーン式の更新操作を提供し、メソッドを連続して呼び出すことで更新条件を構築できます。
@@ -1473,11 +1493,14 @@ lambdaQuery().eq(User::getAge, 30).one(); // 年齢が 30 の単一レコード�
 ```java
 // 链式更改 普通
 UpdateChainWrapper<T> update();
-// 链式更改 lambda 式。注意：不支持 Kotlin
+// 链式更改 lambda 式（3.5.17 以降 Kotlin に対応）
 LambdaUpdateChainWrapper<T> lambdaUpdate();
 ```
 
 **使用例**:
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 // 通常のチェーン式更新の例
@@ -1488,6 +1511,20 @@ User updateUser = new User();
 updateUser.setEmail("new.email@example.com");
 lambdaUpdate().set(User::getEmail, updateUser.getEmail()).eq(User::getId, 1).update(); // ID が 1 のユーザーのメールアドレスを更新
 ```
+
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// 通常のチェーン式更新の例
+update().set("status", "inactive").eq("name", "John").update() // name が "John" のレコードの status を "inactive" に更新
+
+// lambda チェーン式更新の例（3.5.17+）
+lambdaUpdate().set(User::email, "new.email@example.com").eq(User::id, 1).update() // ID が 1 のユーザーのメールアドレスを更新
+```
+
+</TabItem>
+</Tabs>
 
 ### 使用上のヒント
 

--- a/src/content/docs/ja/guides/wrapper.mdx
+++ b/src/content/docs/ja/guides/wrapper.mdx
@@ -4,6 +4,7 @@ sidebar:
   order: 4
 ---
 import Badge from "@/components/Badge.astro";
+import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 MyBatis-Plusは、複雑なデータベースクエリ条件を構築するための強力な条件構築器（Wrapper）を提供しています。Wrapperクラスを使用することで、開発者はチェーン呼び出し方式でクエリ条件を構築でき、煩雑なSQL文を記述する必要がなくなり、開発効率が向上し、SQLインジェクションのリスクを低減できます。
 
@@ -2783,7 +2784,7 @@ class User {
 
 **注意**：上記のコードにおける`@TableId`および`@TableField`アノテーションは、MyBatis-Plusの使用方法を示すためのものであり、必須ではありません。すべてのメンバ変数は、Javaにおける`updateSelective`のようなシナリオで使用できるように、nullable型として定義し、初期値として`null`を設定する必要があります。
 
-`data class`や全パラメータコンストラクタの使用は推奨されません。これは、空のオブジェクトを作成する際に不必要な`null`値を提供しなければならない可能性があるためです。
+`data class`や全パラメータコンストラクタの使用は推奨されません。これは、空のオブジェクトを作成する際に不必要な`null`値を提供しなければならない可能性があるためです。すべてのプロパティがデフォルト値付きのnullableな`var`である場合（クイックスタートチュートリアルの例のように）、Kotlinは引数なしコンストラクタを生成するため、`data class`の使用も問題ありません。この推奨事項は、主にデフォルト値のない全パラメータコンストラクタを対象としています。
 
 ### アノテーションを使用したクエリ
 
@@ -2806,33 +2807,59 @@ List<MysqlData> getAll(Wrapper ew);
 
 ### KotlinでのWrapper使用
 
-Kotlinは`QueryWrapper`と`UpdateWrapper`をサポートしていますが、`LambdaQueryWrapper`と`LambdaUpdateWrapper`はサポートしていません。LambdaスタイルのWrapperを使用する必要がある場合は、`KtQueryWrapper`と`KtUpdateWrapper`を使用できます。
+Kotlinではすべての Wrapper を使用できます：
 
-参考例：
+- `QueryWrapper`と`UpdateWrapper`（文字列カラム名）はすべてのバージョンで使用可能です。
+- `KtQueryWrapper`と`KtUpdateWrapper`は`KProperty`プロパティ参照（`User::name`など）に基づくKotlin専用のLambdaスタイルWrapperで、すべてのバージョンで使用可能です。
+- `3.5.17`以降、`LambdaQueryWrapper`と`LambdaUpdateWrapper`もKotlinをサポートし、Kotlinプロパティ参照（`User::name`）とJavaのgetterメソッド参照の両方が正しく解決されます。それより前のバージョンでは、Kotlinから`KtQueryWrapper`/`KtUpdateWrapper`を使用してください。
+
+`KtQueryWrapper`/`KtUpdateWrapper`の参考例（すべてのバージョンで使用可能）：
 
 ```kotlin
 val queryWrapper = KtQueryWrapper(User()).eq(User::name, "sss").eq(User::roleId, "sss2")
-userMapper!!.selectList(queryWrapper)
+userMapper.selectList(queryWrapper)
 
 val updateConditionWrapper = KtUpdateWrapper(User()).eq(User::name, "sss").eq(User::roleId, "sss2")
 val updateRecord = User()
 updateRecord.name = "newName"
-userMapper!!.update(updateRecord, updateConditionWrapper)
+userMapper.update(updateRecord, updateConditionWrapper)
 
-val updateRecord = User()
-updateRecord.id = 2
-updateRecord.name = "haha"
-userMapper.updateById(updateRecord)
+val newRecord = User()
+newRecord.id = 2
+newRecord.name = "haha"
+userMapper.updateById(newRecord)
 ```
+
+`LambdaQueryWrapper`/`LambdaUpdateWrapper`の参考例（`3.5.17`+）：
+
+```kotlin
+val users = userMapper.selectList(LambdaQueryWrapper(User::class.java).eq(User::name, "sss"))
+
+userMapper.update(
+    null,
+    LambdaUpdateWrapper(User::class.java).set(User::name, "newName").eq(User::roleId, "sss2")
+)
+```
+
+:::note
+- `3.5.17`より前のバージョンでは、Kotlinから`LambdaQueryWrapper`などのLambdaスタイルWrapperを使用すると、実行時に`Error parsing property name 'xxx$lambda$0'. Didn't start with 'is', 'get' or 'set'.`のような例外が発生します。
+- MyBatis-Plus `3.5.17`はKotlin `2.4.0`でコンパイルされており、そのKotlinメタデータを読み取るには`2.3`以上のKotlinコンパイラが必要です。
+- `-Xsam-conversions=class`オプションでコンパイルされたKotlinコードでは、Javaのgetterメソッド参照は引き続き解決できません。
+:::
+
+完全な実行可能サンプルは [mybatis-plus-sample-kotlin](https://github.com/baomidou/mybatis-plus-samples/tree/master/mybatis-plus-sample-kotlin) を参照してください。
 
 ### チェーンメソッド呼び出しとラムダ式呼び出し
 
-MyBatis-Plusは2種類のチェーンメソッド呼び出しスタイルを提供しています：通常のチェーンメソッド呼び出しとラムダ式チェーンメソッド呼び出しです。注意点として、ラムダ式チェーンメソッド呼び出しはKotlinではサポートされていません。
+MyBatis-Plusは2種類のチェーンメソッド呼び出しスタイルを提供しています：通常のチェーンメソッド呼び出しとラムダ式チェーンメソッド呼び出しです。`3.5.17`以降、ラムダ式チェーンメソッド呼び出しもKotlinをサポートしています。それより前のバージョンでは、Kotlinから`KtQueryChainWrapper`と`KtUpdateChainWrapper`を使用できます。
+
+<Tabs syncKey="code-lang">
+<TabItem label="Java">
 
 ```java
 // 通常のチェーンメソッド呼び出し
 UpdateChainWrapper<T> update();
-// ラムダ式チェーンメソッド呼び出し（Kotlinではサポートされていません）
+// ラムダ式チェーンメソッド呼び出し
 LambdaUpdateChainWrapper<T> lambdaUpdate();
 
 // 同等の例：
@@ -2843,5 +2870,23 @@ lambdaQuery().eq(Entity::getId, value).one();
 update().eq("id", value).remove();
 lambdaUpdate().eq(Entity::getId, value).remove();
 ```
+
+</TabItem>
+<TabItem label="Kotlin">
+
+```kotlin
+// 通常のチェーンメソッド呼び出し
+QueryChainWrapper(userMapper).eq("name", "Jack").list()
+
+// ラムダ式チェーンメソッド呼び出し（3.5.17+）
+LambdaQueryChainWrapper(userMapper).eq(User::name, "Jack").one()
+LambdaUpdateChainWrapper(userMapper).set(User::name, "newName").eq(User::name, "Jack").update()
+
+// KPropertyスタイルのチェーンメソッド呼び出し（すべてのバージョンで使用可能）
+KtQueryChainWrapper(userMapper, User::class.java).eq(User::name, "Jack").one()
+```
+
+</TabItem>
+</Tabs>
 
 これらのベストプラクティスに従うことで、Kotlinにおける永続化オブジェクトの定義を明確かつ保守しやすい状態に保ちながら、MyBatis-Plusが提供する機能を十分に活用することができます。


### PR DESCRIPTION
## 说明

自 `3.5.17`（baomidou/mybatis-plus#7100，changelog："新增 Kotlin 支持 LambdaQueryWrapper 执行能力"）起，`LambdaQueryWrapper`/`LambdaUpdateWrapper` 及 Lambda 式链式调用可以正确解析 Kotlin 属性引用。本 PR 更新条件构造器与持久层接口两篇文档中已过时的"不支持 Kotlin"说明（覆盖中、英、日三个语言版本）：

- 重写"Kotlin中使用Wrapper"小节：按版本说明各 Wrapper 在 Kotlin 下的可用性，新增 `LambdaQueryWrapper` Kotlin 示例；
- 链式调用示例增加 Java/Kotlin 切换标签；
- 补充注意事项：低于 3.5.17 版本的运行时报错信息、3.5.17 使用 Kotlin 2.4.0 编译（读取其 Kotlin 元数据需要 2.3+ 编译器）、`-Xsam-conversions=class` 下 Java getter 引用仍不可解析；
- 顺带修复 Kt Wrapper 示例中重复声明 `val updateRecord` 的问题（无法编译的 Kotlin 代码）；
- 链接到可运行示例 mybatis-plus-sample-kotlin。

以上行为均已通过针对 3.5.16 / 3.5.17 的测试验证（3.5.16 下 Lambda 风格调用抛出 `Error parsing property name ... Didn't start with 'is', 'get' or 'set'`，3.5.17 下全部通过）。

## English summary

Updates the stale "Kotlin not supported" claims in the wrapper and data-interface guides (zh/en/ja): since 3.5.17 (#7100) the lambda wrappers and lambda chain calls resolve Kotlin property references. Adds versioned guidance, Kotlin examples, Java/Kotlin tabs on chain examples, honest notes (pre-3.5.17 runtime error, Kotlin 2.3+ compiler requirement for 3.5.17 metadata, -Xsam-conversions=class limitation), fixes an invalid duplicate `val` declaration in the existing example, and links the runnable kotlin sample. All claims verified with tests against both 3.5.16 and 3.5.17.

`npm run build` passes: 153 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)